### PR TITLE
pass in options as an object for readFileSync & createReadStream

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,12 +23,12 @@ exports.HOSTS = WINDOWS
 exports.get = function (preserveFormatting, cb) {
   var lines = []
   if (typeof cb !== 'function') {
-    fs.readFileSync(exports.HOSTS, 'utf8').split(/\r?\n/).forEach(online)
+    fs.readFileSync(exports.HOSTS, { encoding: 'utf8' }).split(/\r?\n/).forEach(online)
     return lines
   }
 
   cb = once(cb)
-  fs.createReadStream(exports.HOSTS, 'utf8')
+  fs.createReadStream(exports.HOSTS, { encoding: 'utf8' })
     .pipe(split())
     .pipe(through(online))
     .on('close', function () {


### PR DESCRIPTION
v1.0.1 is currently broken with io.js 1.8.1 (and I assume node 0.12)

```js
TypeError: Object prototype may only be an Object or null: utf8
    at Function.create (native)
    at new ReadStream (fs.js:1621:20)
    at Object.fs.createReadStream (fs.js:1610:10)
    at Object.exports.get ({path}/node_modules/hostile/index.js:31:6)
    at Object.exports.set ({path}/node_modules/hostile/index.js:67:11)
    at checkHostsPermissions ({path}/lib/commands/configure.js:13:13)
    at Command.module.exports ({path}/lib/commands/configure.js:56:5)
    at Command.listener ({path}/node_modules/commander/index.js:249:8)
    at emitTwo (events.js:87:13)
    at Command.emit (events.js:169:7)
```

an object is what the node api suggests, and I couldn't even find a reference that allows a string...