### PR TITLE
Fixed line break bug within Alpine Linux

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ exports.writeFile = function (lines, cb) {
   lines = lines.map(function (line, lineNum) {
     if (Array.isArray(line))
       line = line[0] + ' ' + line[1]
-    return line + (lineNum === lines.length - 1 ? '' : EOL)
+    return line + (lineNum === lines.length - 2 ? '' : EOL)
   })
 
   if (typeof cb !== 'function') {


### PR DESCRIPTION
- Fixed line break bug that causes Alpine Linux to not acknowledge the last entry

Here's a screenshot of how the ```/etc/hosts``` file looks after the change:
![screen shot 2016-07-14 at 17 17 05](https://cloud.githubusercontent.com/assets/698574/16859994/78d3ee64-49e8-11e6-81ef-c1c82a0f861d.png)

https://github.com/feross/hostile/issues/16