### PR TITLE
Add the ability to load/unload hosts from a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,40 @@ example:
 hostile remove domain.com
 ```
 
+#### load a set of hosts from a file
+
+```bash
+hostile load [file_path]
+```
+hosts.txt
+```bash
+# hosts.txt
+127.0.0.1 github.com
+127.0.0.1 twitter.com
+```
+
+example:
+```bash
+hostile load hosts.txt
+```
+
+#### unload [remove] a set of hosts from a file
+
+```bash
+hostile unload [file_path]
+```
+
+```bash
+# hosts.txt
+127.0.0.1 github.com
+127.0.0.1 twitter.com
+```
+
+example:
+```bash
+hostile unload hosts.txt
+```
+
 #### set up auto completion
 
 bash:
@@ -111,7 +145,24 @@ hostile.get(preserveFormatting, function (err, lines) {
     console.error(err.message)
   }
   lines.forEach(function (line) {
-    console.log(line)
+    console.log(line) // [IP, Host]
+  })
+})
+```
+
+#### get all lines in any file
+
+```js
+// If `preserveFormatting` is true, then include comments, blank lines and other
+// non-host entries in the result
+var preserveFormatting = false
+
+hostile.getFile(file_path, preserveFormatting, function (err, lines) {
+  if (err) {
+    console.error(err.message)
+  }
+  lines.forEach(function (line) {
+    console.log(line) // [IP, Host]
   })
 })
 ```

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -13,6 +13,8 @@ var command = argv._[0]
 if (command === 'list' || command === 'ls') list()
 if (command === 'set') set(argv._[1], argv._[2])
 if (command === 'remove') remove(argv._[1])
+if (command === 'load') load(argv._[1])
+if (command === 'unload') unload(argv._[1])
 if (!command) help()
 
 /**
@@ -27,6 +29,8 @@ function help () {
       list                   List all current domain records in hosts file
       set [ip] [host]        Set a domain in the hosts file
       remove [domain]        Remove a domain from the hosts file
+      load [file]            Load a set of host entries from a file
+      unload [file]          Remove a set of host entries from a file
 
   */ }.toString().split(/\n/).slice(1, -1).join('\n'))
 }
@@ -95,6 +99,46 @@ function remove (host) {
       console.log(chalk.green('Removed ' + host))
     }
   })
+}
+
+/**
+ * Load hosts given a file
+ * @param {string} file_path
+ */
+function load (file_path) {
+  var lines = parseFile(file_path)
+
+  lines.forEach(function (item) {
+    set(item[0], item[1]);
+  })
+  console.log(chalk.green("\nAdded %d hosts!"), lines.length);
+}
+
+/**
+ * Remove hosts given a file
+ * @param {string} file_path
+ */
+function unload (file_path) {
+  var lines = parseFile(file_path)
+
+  lines.forEach(function (item) {
+    hostile.remove(item[0], item[1]);
+  })
+  console.log(chalk.green("Added %d removed!"), lines.length);
+}
+
+/**
+ * Get all the lines of the file as array of arrays [[IP, host]]
+ * @param {string} file_path
+ */
+function parseFile(file_path) {
+  var lines
+  try {
+    lines = hostile.getFile(file_path, false);
+  } catch (err) {
+    return error(err)
+  }
+  return lines;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hostile",
   "description": "Simple /etc/hosts manipulation",
-  "version": "1.0.3",
+  "version": "1.1.3",
   "author": "Feross Aboukhadijeh <feross@feross.org> (http://feross.org/)",
   "bin": {
     "hostile": "bin/cmd.js"


### PR DESCRIPTION
You can now `load` and `unload` hosts given a new line separated file of host entries.

I can add in tests if need be, but it seems to use all the existing functionality that was initially tested.

Issue: #21 