### PR TITLE
Remove trailing whitespace from parsed domains

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ exports.getFile = function (filePath, preserveFormatting, cb) {
   function online (line) {
     // Remove all comment text from the line
     var lineSansComments = line.replace(/#.*/, '')
-    var matches = /^\s*?(.+?)\s+(.+?)$/.exec(lineSansComments)
+    var matches = /^\s*?(.+?)\s+(\S+?)\s*$/.exec(lineSansComments)
     if (matches && matches.length === 3) {
       // Found a hosts entry
       var ip = matches[1]


### PR DESCRIPTION
Whitespace after the domain name shouldn't be considered part of the domain

Currently, a line with a space and comment at the end of the line like

```
127.0.0.1 myhost.dev # for local dev
``` 

is parsed as `['127.0.0.1', 'myhost.dev ']`