### PR TITLE
handle space-separated domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+#npm
+node_modules/

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ exports.getFile = function (filePath, preserveFormatting, cb) {
   function online (line) {
     // Remove all comment text from the line
     var lineSansComments = line.replace(/#.*/, '')
-    var matches = /^\s*?(.+?)\s+(\S+?)\s*$/.exec(lineSansComments)
+    var matches = /^\s*?(.+?)\s+(.+)\s*$/.exec(lineSansComments)
     if (matches && matches.length === 3) {
       // Found a hosts entry
       var ip = matches[1]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hostile",
   "description": "Simple /etc/hosts manipulation",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": "Feross Aboukhadijeh <feross@feross.org> (http://feross.org/)",
   "bin": {
     "hostile": "bin/cmd.js"

--- a/test/basic.js
+++ b/test/basic.js
@@ -67,3 +67,20 @@ test('remove', function (t) {
     })
   })
 })
+
+test('space-separated domains', function (t) {
+  t.plan(2)
+  hostile.set('127.0.0.5', 'www.peercdn.com  m.peercdn.com', function (err) {
+    t.error(err)
+    hostile.get(false, function (err, lines) {
+      t.error(err)
+      var finds = lines.filter(function (line) {
+        return line[0] === '127.0.0.5' && line[1] === 'www.peercdn.com  m.peercdn.com'
+      })
+
+      if (finds.length === 0) {
+        t.fail('add space-separated domain failed')
+      }
+    })
+  })
+})


### PR DESCRIPTION
The space-separated domain cannot be handled correctly in previous version, for example:

If i have an host rule like: 

```
127.0.0.5 www.peercdn.com  m.peercdn.com
```

The host rule gets matched looks like:

```javascript
['127.0.0.5 www.peercdn.com', 'm.peercdn.com']
```

Which is incorrect obviously.