### PR TITLE
Fix unload command and make remove match the index.js comparison logic

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -90,7 +90,7 @@ function remove (host) {
     return error(err)
   }
   lines.forEach(function (item) {
-    if (item[1].indexOf(host) > -1) {
+    if (item[1] === host) {
       try {
         hostile.remove(item[0], host)
       } catch (err) {
@@ -122,7 +122,7 @@ function unload (filePath) {
   var lines = parseFile(filePath)
 
   lines.forEach(function (item) {
-    remove(item[0], item[1])
+    remove(item[1])
   })
   console.log(chalk.green('Removed %d hosts!'), lines.length)
 }


### PR DESCRIPTION
The unload command in bin/cmd.js has an error, where it is passing the two components of a hosts file entry to the remove function. However, the remove function in that file only expects the host name, not both components, so it tries to compare the IP address to host name, and nothing is removed. This fixes the problem.

The remove function was also doing an indexOf compare to find the hosts to remove, meaning that it could remove several. This is fine, except that it is different behavior than the remove function in index.js, which looks for an exact match. I changed it to be consistent with index.js and with the function documentation, which indicates that it removes "a" (singular) host.