### PR TITLE
Replace @ljharb/through with native solution

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 var fs = require('fs')
 var once = require('once')
 var split = require('split')
-var through = require('@ljharb/through')
+var { Writable } = require('node:stream')
 var net = require('net')
 
 var WINDOWS = process.platform === 'win32'
@@ -33,7 +33,12 @@ exports.getFile = function (filePath, preserveFormatting, cb) {
   cb = once(cb)
   fs.createReadStream(filePath, { encoding: 'utf8' })
     .pipe(split())
-    .pipe(through(online))
+    .pipe(new Writable({
+      write: (chunk, encoding, callback) => {
+        online(chunk.toString())
+        callback()
+      }
+    }))
     .on('close', function () {
       cb(null, lines)
     })

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "url": "https://github.com/feross/hostile/issues"
   },
   "dependencies": {
-    "@ljharb/through": "^2.3.11",
     "chalk": "^4.1.2",
     "minimist": "^1.2.8",
     "once": "^1.4.0",


### PR DESCRIPTION
Considering that CI is only executed on Node 14, it can be implied that very old Node.js version are not supported by this library.

Therefore it it possible to benefit from using native Node.js functionality and remove the unnecessary dependency.